### PR TITLE
feat: Zeppelin as baikal UI FPF-10227

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.class
 *.pyc
+*.bsp
 
 # Package Files #
 *.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM openjdk:8 as builder
+FROM openjdk:11 as builder
 ADD . /workspace/zeppelin
 WORKDIR /workspace/zeppelin
 ENV MAVEN_OPTS="-Xms1024M -Xmx2048M -XX:MaxMetaspaceSize=1024m -XX:-UseGCOverheadLimit -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 # Allow npm and bower to run with root privileges
 RUN echo "unsafe-perm=true" > ~/.npmrc && \
     echo '{ "allow_root": true }' > ~/.bowerrc && \
-    ./mvnw -B package -DskipTests -Pbuild-distr -Pspark-3.2 -Pinclude-hadoop -Phadoop3 -Pspark-scala-2.12 -Pweb-angular -Pweb-dist && \
+    ./mvnw -e -B package -DskipTests -Pbuild-distr -Pspark-3.2 -Pinclude-hadoop -Phadoop3 -Pspark-scala-2.12 -Pweb-angular -Pweb-dist && \
     # Example with doesn't compile all interpreters
     # ./mvnw -B package -DskipTests -Pbuild-distr -Pspark-3.2 -Pinclude-hadoop -Phadoop3 -Pspark-scala-2.12 -Pweb-angular -Pweb-dist -pl '!groovy,!submarine,!livy,!hbase,!file,!flink' && \
     mv /workspace/zeppelin/zeppelin-distribution/target/zeppelin-*/zeppelin-* /opt/zeppelin/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV MAVEN_OPTS="-Xms1024M -Xmx2048M -XX:MaxMetaspaceSize=1024m -XX:-UseGCOverhea
 # Allow npm and bower to run with root privileges
 RUN echo "unsafe-perm=true" > ~/.npmrc && \
     echo '{ "allow_root": true }' > ~/.bowerrc && \
-    ./mvnw -e -B package -DskipTests -Pbuild-distr -Pspark-3.2 -Pinclude-hadoop -Phadoop3 -Pspark-scala-2.12 -Pweb-angular -Pweb-dist && \
+    ./mvnw -e -B package -DskipTests -Pbuild-distr -Pspark-3.3 -Pinclude-hadoop -Phadoop3 -Pspark-scala-2.12 -Pweb-angular -Pweb-dist && \
     # Example with doesn't compile all interpreters
     # ./mvnw -B package -DskipTests -Pbuild-distr -Pspark-3.2 -Pinclude-hadoop -Phadoop3 -Pspark-scala-2.12 -Pweb-angular -Pweb-dist -pl '!groovy,!submarine,!livy,!hbase,!file,!flink' && \
     mv /workspace/zeppelin/zeppelin-distribution/target/zeppelin-*/zeppelin-* /opt/zeppelin/ && \

--- a/pom.xml
+++ b/pom.xml
@@ -103,10 +103,10 @@
     <!-- These two lines could be changed like `maven.compiler.release` after updating JDK11 -->
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <scala.version>${scala.2.11.version}</scala.version>
-    <scala.binary.version>2.11</scala.binary.version>
+    <scala.version>${scala.2.12.version}</scala.version>
+    <scala.binary.version>2.12</scala.binary.version>
     <scala.2.11.version>2.11.12</scala.2.11.version>
-    <scala.2.12.version>2.12.16</scala.2.12.version>
+    <scala.2.12.version>2.12.15</scala.2.12.version>
     <scalatest.version>3.0.7</scalatest.version>
     <scalacheck.version>1.12.5</scalacheck.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- language versions -->
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <!-- These two lines could be changed like `maven.compiler.release` after updating JDK11 -->
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/scripts/docker/zeppelin-interpreter/Dockerfile
+++ b/scripts/docker/zeppelin-interpreter/Dockerfile
@@ -27,7 +27,7 @@ ENV VERSION="${version}" \
 
 RUN set -ex && \
     apt-get -y update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jre-headless wget tini && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-11-jre-headless wget tini && \
     # Cleanup
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoclean && \

--- a/scripts/docker/zeppelin-interpreter/log4j.properties
+++ b/scripts/docker/zeppelin-interpreter/log4j.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-log4j.rootLogger = INFO, stdout
+log4j.rootLogger = ERROR, stdout
 
 log4j.appender.stdout = org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout = org.apache.log4j.PatternLayout

--- a/scripts/docker/zeppelin-interpreter/log4j_yarn_cluster.properties
+++ b/scripts/docker/zeppelin-interpreter/log4j_yarn_cluster.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-log4j.rootLogger = INFO, stdout
+log4j.rootLogger = ERROR, stdout
 
 log4j.appender.stdout = org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout = org.apache.log4j.PatternLayout

--- a/scripts/docker/zeppelin-server/Dockerfile
+++ b/scripts/docker/zeppelin-server/Dockerfile
@@ -30,7 +30,7 @@ LABEL maintainer="Apache Software Foundation <dev@zeppelin.apache.org>"
 RUN set -ex && \
     apt-get -y update && \
     # Install language and other base packages
-    DEBIAN_FRONTEND=noninteractive apt-get install -y language-pack-en openjdk-8-jre-headless tini wget && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y language-pack-en openjdk-11-jre-headless tini wget && \
     # Cleanup
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoclean && \
@@ -40,7 +40,7 @@ ARG version="0.10.0"
 
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
+    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 \
     VERSION="${version}" \
     HOME="/opt/zeppelin" \
     ZEPPELIN_HOME="/opt/zeppelin" \

--- a/scripts/docker/zeppelin-server/log4j.properties
+++ b/scripts/docker/zeppelin-server/log4j.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-log4j.rootLogger = INFO, stdout
+log4j.rootLogger = ERROR, stdout
 
 log4j.appender.stdout = org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout = org.apache.log4j.PatternLayout

--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -13,11 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM baikalpublicimages.azurecr.io/apache/zeppelin:0.11.0-SNAPSHOT as zeppelin-build
 FROM ubuntu:20.04
 
 LABEL maintainer="Apache Software Foundation <dev@zeppelin.apache.org>"
 
-ENV Z_VERSION="0.10.0"
+ENV Z_VERSION="0.11.0-SNAPSHOT"
 
 ENV LOG_TAG="[ZEPPELIN_${Z_VERSION}]:" \
     ZEPPELIN_HOME="/opt/zeppelin" \
@@ -63,11 +64,9 @@ RUN set -ex && \
     # chmod -R ug+rwX /opt/conda
 ENV PATH /opt/conda/envs/python_3_with_R/bin:/opt/conda/bin:$PATH
 
+COPY --from=zeppelin-build /opt/zeppelin ${ZEPPELIN_HOME}
+
 RUN echo "$LOG_TAG Download Zeppelin binary" && \
-    mkdir -p ${ZEPPELIN_HOME} && \
-    wget -nv -O /tmp/zeppelin-${Z_VERSION}-bin-all.tgz https://archive.apache.org/dist/zeppelin/zeppelin-${Z_VERSION}/zeppelin-${Z_VERSION}-bin-all.tgz && \
-    tar --strip-components=1 -zxvf  /tmp/zeppelin-${Z_VERSION}-bin-all.tgz -C ${ZEPPELIN_HOME} && \
-    rm -f /tmp/zeppelin-${Z_VERSION}-bin-all.tgz && \
     chown -R root:root ${ZEPPELIN_HOME} && \
     mkdir -p ${ZEPPELIN_HOME}/logs ${ZEPPELIN_HOME}/run ${ZEPPELIN_HOME}/webapps && \
     # Allow process to edit /etc/passwd, to create a user entry for zeppelin

--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -25,13 +25,13 @@ ENV LOG_TAG="[ZEPPELIN_${Z_VERSION}]:" \
     HOME="/opt/zeppelin" \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
+    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 \
     ZEPPELIN_ADDR="0.0.0.0"
 
 RUN echo "$LOG_TAG install basic packages" && \
     apt-get -y update && \
     # Switch back to install JRE instead of JDK when moving to JDK9 or later.
-    DEBIAN_FRONTEND=noninteractive apt-get install -y locales language-pack-en tini openjdk-8-jdk-headless wget unzip && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y locales language-pack-en tini openjdk-11-jdk-headless wget unzip && \
     # Cleanup
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoclean && \

--- a/scripts/docker/zeppelin/bin/log4j.properties
+++ b/scripts/docker/zeppelin/bin/log4j.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-log4j.rootLogger = INFO, stdout
+log4j.rootLogger = ERROR, stdout
 
 log4j.appender.stdout = org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout = org.apache.log4j.PatternLayout

--- a/scripts/docker/zeppelin/bin/log4j2.properties
+++ b/scripts/docker/zeppelin/bin/log4j2.properties
@@ -17,7 +17,7 @@
 ################################################################################
 
 # This affects logging for both user code and Flink
-rootLogger.level = INFO
+rootLogger.level = ERROR
 rootLogger.appenderRef.file.ref = MainAppender
 
 # Uncomment this if you want to _only_ change Flink's logging

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -48,7 +48,7 @@
     <spark.version>3.1.2</spark.version>
     <protobuf.version>2.5.0</protobuf.version>
     <py4j.version>0.10.9</py4j.version>
-    <spark.scala.version>2.12.7</spark.scala.version>
+    <spark.scala.version>2.12.15</spark.scala.version>
     <spark.scala.binary.version>2.12</spark.scala.binary.version>
 
     <spark.archive>spark-${spark.version}</spark.archive>
@@ -511,7 +511,7 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <spark.scala.version>2.12.7</spark.scala.version>
+        <spark.scala.version>2.12.15</spark.scala.version>
         <spark.scala.binary.version>2.12</spark.scala.binary.version>
       </properties>
     </profile>

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkScalaInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkScalaInterpreter.java
@@ -234,9 +234,14 @@ public abstract class AbstractSparkScalaInterpreter {
     try {
       scalaInterpretQuietly("import com.telefonica.baikal.baikonur.annotations._");
       scalaInterpretQuietly("import com.telefonica.baikal.baikonur.implicits.audit.Implicits._");
+      scalaInterpretQuietly("import com.telefonica.baikal.baikonur.implicits.dimensionalEntities.Implicits._");
+      scalaInterpretQuietly("import com.telefonica.baikal.baikonur.implicits.general.Implicits._");
       scalaInterpretQuietly("import com.telefonica.baikal.baikonur.implicits.dataset.Implicits._");
       scalaInterpretQuietly("import com.telefonica.baikal.baikonur.implicits.spark.Implicits._");
       scalaInterpretQuietly("import com.telefonica.baikal.baikonur.model.audit._");
+      scalaInterpretQuietly("import com.telefonica.baikal.baikonur.model.dimensionalEntities._");
+      scalaInterpretQuietly("import com.telefonica.baikal.baikonur.model.general._");
+      scalaInterpretQuietly("import com.telefonica.baikal.baikonur.utils.DateFormatters._");
     } catch (Exception e) {
       LOGGER.warn("Error importing Baikonur classes");
     }

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkScalaInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkScalaInterpreter.java
@@ -229,6 +229,9 @@ public abstract class AbstractSparkScalaInterpreter {
     scalaInterpretQuietly("import sqlContext.implicits._");
     scalaInterpretQuietly("import spark.sql");
     scalaInterpretQuietly("import org.apache.spark.sql.functions._");
+    scalaInterpretQuietly("import com.telefonica.baikal.datasets.implicits.Implicits._");
+    scalaInterpretQuietly("import com.telefonica.baikal.datasets.model._");
+    scalaInterpretQuietly("import org.apache.spark.sql._");
     // print empty string otherwise the last statement's output of this method
     // (aka. import org.apache.spark.sql.functions._) will mix with the output of user code
     scalaInterpretQuietly("print(\"\")");

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkScalaInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkScalaInterpreter.java
@@ -229,9 +229,18 @@ public abstract class AbstractSparkScalaInterpreter {
     scalaInterpretQuietly("import sqlContext.implicits._");
     scalaInterpretQuietly("import spark.sql");
     scalaInterpretQuietly("import org.apache.spark.sql.functions._");
-    scalaInterpretQuietly("import com.telefonica.baikal.datasets.implicits.Implicits._");
-    scalaInterpretQuietly("import com.telefonica.baikal.datasets.model._");
     scalaInterpretQuietly("import org.apache.spark.sql._");
+
+    try {
+      scalaInterpretQuietly("import com.telefonica.baikal.baikonur.annotations._");
+      scalaInterpretQuietly("import com.telefonica.baikal.baikonur.implicits.audit.Implicits._");
+      scalaInterpretQuietly("import com.telefonica.baikal.baikonur.implicits.dataset.Implicits._");
+      scalaInterpretQuietly("import com.telefonica.baikal.baikonur.implicits.spark.Implicits._");
+      scalaInterpretQuietly("import com.telefonica.baikal.baikonur.model.audit._");
+    } catch (Exception e) {
+      LOGGER.warn("Error importing Baikonur classes");
+    }
+
     // print empty string otherwise the last statement's output of this method
     // (aka. import org.apache.spark.sql.functions._) will mix with the output of user code
     scalaInterpretQuietly("print(\"\")");

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -41,7 +41,7 @@
         <spark.version>3.1.2</spark.version>
         <protobuf.version>2.5.0</protobuf.version>
         <py4j.version>0.10.9</py4j.version>
-        <spark.scala.version>2.12.7</spark.scala.version>
+        <spark.scala.version>2.12.15</spark.scala.version>
         <spark.scala.binary.version>2.12</spark.scala.binary.version>
 
         <scala.compile.version>${spark.scala.version}</scala.compile.version>

--- a/spark/spark-scala-parent/pom.xml
+++ b/spark/spark-scala-parent/pom.xml
@@ -33,8 +33,8 @@
 
     <properties>
         <spark.version>2.4.5</spark.version>
-        <spark.scala.binary.version>2.11</spark.scala.binary.version>
-        <spark.scala.version>2.11.12</spark.scala.version>
+        <spark.scala.binary.version>2.12</spark.scala.binary.version>
+        <spark.scala.version>2.12.15</spark.scala.version>
         <spark.scala.compile.version>${spark.scala.binary.version}</spark.scala.compile.version>
     </properties>
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -48,9 +48,11 @@
   margin-bottom: 0;
 }
 
+/*
 .paragraph div svg {
   width: 100%;
 }
+*/
 
 .plainTextContainer {
   font-family: "Monaco","Menlo","Ubuntu Mono","Consolas","source-code-pro",monospace;


### PR DESCRIPTION
This PR contains all the changes necessary to support Kernel SDK 2.2.0 (and Baikonur) in Zeppelin's Spark interpreters. In detail:

* Java 11 support.
* Scala 2.12 support.
* Spark 3.3 support.
* baikalpublicimages as images repository.
* Java includes regarding Baikonur.